### PR TITLE
Fix ambiguity of the `install` task in the benchmark scripts

### DIFF
--- a/run-android-studio-benchmark.sh
+++ b/run-android-studio-benchmark.sh
@@ -13,7 +13,7 @@ fi
 
 sync
 
-gradle-profiler/gradlew --project-dir gradle-profiler install
+gradle-profiler/gradlew --project-dir gradle-profiler installDist
 
 gradle-profiler/build/install/gradle-profiler/bin/gradle-profiler \
     -DagpVersion=$AGP_VERSION \

--- a/run-incremental-benchmark.sh
+++ b/run-incremental-benchmark.sh
@@ -7,7 +7,7 @@ BENCHMARK="${BENCHMARK:-no-optimizations only-file-system-watching only-configur
 
 sync
 
-gradle-profiler/gradlew --project-dir gradle-profiler install
+gradle-profiler/gradlew --project-dir gradle-profiler installDist
 
 gradle-profiler/build/install/gradle-profiler/bin/gradle-profiler \
     -DagpVersion=$AGP_VERSION \


### PR DESCRIPTION
Running the benchmarks with the latest `gradle-profiler` leads to the problem of the `install` task being ambiguous.

```
FAILURE: Build failed with an exception.

* What went wrong:
Task 'install' is ambiguous in root project 'gradle-profiler'. Candidates are: 'installAndroidSdk', 'installDist'.
```

This PR updates the gradle-profiler and fixes the problem.